### PR TITLE
Add the authenticated users URI as a Grantee URI to check

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ exports.handler = (event, context) => {
         // Grant[0] is always owner, so we only need to check further if we have more than 1 grant
         if (grants.length > 1) {
             for (const grant of grants) {
-                if (grant.Grantee.URI && (grant.Grantee.URI == allUsersUri || grant.Grantee.URI == authenticatedUsersUri) {
+                if (grant.Grantee.URI && (grant.Grantee.URI == allUsersUri || grant.Grantee.URI == authenticatedUsersUri)) {
                     if (grant.Permission == "READ") {
                         publicPermissions.push("read");
                     } else {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const AWS = require("aws-sdk");
 const allUsersUri = "http://acs.amazonaws.com/groups/global/AllUsers";
+const authenticatedUsersUri = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
 const snoozeTopic = process.env.snsTopicArn;
 
 exports.handler = (event, context) => {
@@ -21,7 +22,7 @@ exports.handler = (event, context) => {
         // Grant[0] is always owner, so we only need to check further if we have more than 1 grant
         if (grants.length > 1) {
             for (const grant of grants) {
-                if (grant.Grantee.URI && grant.Grantee.URI == allUsersUri) {
+                if (grant.Grantee.URI && (grant.Grantee.URI == allUsersUri || grant.Grantee.URI == authenticatedUsersUri) {
                     if (grant.Permission == "READ") {
                         publicPermissions.push("read");
                     } else {


### PR DESCRIPTION
The ["Authenticated Users group" predefined group](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#specifying-grantee-predefined-groups) is also a group that can be in an ACL that grants effective public access to an S3 bucket:

>Authenticated Users group – Represented by http://acs.amazonaws.com/groups/global/AuthenticatedUsers.
>T**his group represents all AWS accounts.** Access permission to this group allows any AWS account to access the resource. However, all requests must be signed (authenticated).
>Warning
>**When you grant access to the Authenticated Users group any AWS authenticated user in the world can access your resource.**

This PR adds the group and checks for it.

Public access at the bucket level could also be done via bucket policy, but that's a bit tricker than just knowing a couple predefined groups to check for on an ACL and is outside the scope of this PR.